### PR TITLE
Add Java 8 requirement for building using Maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ You may build the project and generate the JAR as follows from your local copy o
     $ mvn package
 </code></pre>
 
+Note that you must use Java 8 to run Maven when building the project.
+
 ### Dependency management
 1. No SNAPSHOT dependencies on "develop" and obviously "master" branches
 


### PR DESCRIPTION
java.xml.bind is no longer part of Java SE (starting with version 11, was disable by default in version 10).
This change make the build fail if using Java 11.
I added a note in the "Building the project" section to warn the user.
Long term solution would be to update the project dependency to add the missing library.