### PR TITLE
Update reference to use latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.ow2.authzforce</groupId>
 		<artifactId>authzforce-ce-parent</artifactId>
-		<version>8.0.1</version>
+		<version>8.0.2</version>
 	</parent>
 	<artifactId>authzforce-ce-core</artifactId>
 	<version>17.1.1-SNAPSHOT</version>


### PR DESCRIPTION
Use latest version to get CVE fix for Spring framework once authzforce/parent#2 is merged.