### PR TITLE
Update MongoDB driver to 5.11.1

### DIFF
--- a/pdp-testutils/pom.xml
+++ b/pdp-testutils/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.10.0</version>
+            <version>5.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
  - Update `mongodb-driver-sync` from `5.10.0` to `5.11.1`.
  - Fix the vulnerability reported as CVE-2026-88033 / GHSA-556f-q76p-2vxq.
  - Update the transitive `mongodb-driver-core` dependency to the patched version.